### PR TITLE
Add TCP/UDP protocol estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
  # Transfer Time Calculator
 
- A simple static website for calculating theoretical transfer times based on file size and bandwidth.
+A simple static website for calculating theoretical transfer times based on file size,
+bandwidth and network protocol (TCP or UDP).
 
  ## Prerequisites
  - bun (>=0.6.0) or Node.js (>=14)
@@ -40,10 +41,12 @@
  ```
 
  ## Usage
- 1. Open the web UI in your browser.
- 2. Enter a file size and select its unit.
- 3. Enter a bandwidth value and select its unit.
- 4. Click **Calculate** to see the estimated transfer time.
+1. Open the web UI in your browser.
+2. Enter a file size and select its unit.
+3. Enter a bandwidth value and select its unit.
+4. Choose a protocol (TCP or UDP). If TCP is selected, provide the round-trip latency in milliseconds.
+5. Select the IP version (IPv4 or IPv6) to account for header differences.
+6. Click **Calculate** to see the estimated transfer time.
 
  ## Project Structure
  - `index.html`: Main HTML template

--- a/index.html
+++ b/index.html
@@ -50,6 +50,27 @@
                 <div id="bandwidth-help" class="sr-only">Enter bandwidth and select unit.</div>
             </div>
             <div class="input-section">
+                <label for="protocol-select">Protocol:</label>
+                <select id="protocol-select" aria-describedby="protocol-help">
+                    <option value="TCP" selected>TCP</option>
+                    <option value="UDP">UDP</option>
+                </select>
+                <div id="protocol-help" class="sr-only">Choose TCP or UDP.</div>
+            </div>
+            <div class="input-section">
+                <label for="ip-version-select">IP Version:</label>
+                <select id="ip-version-select" aria-describedby="ip-version-help">
+                    <option value="IPv4" selected>IPv4</option>
+                    <option value="IPv6">IPv6</option>
+                </select>
+                <div id="ip-version-help" class="sr-only">Choose IPv4 or IPv6.</div>
+            </div>
+            <div id="latency-section" class="input-section">
+                <label for="latency-input">Latency (ms):</label>
+                <input type="number" id="latency-input" placeholder="0" min="0" step="any" aria-describedby="latency-help">
+                <div id="latency-help" class="sr-only">Round-trip latency for TCP in milliseconds.</div>
+            </div>
+            <div class="input-section">
                 <label for="overhead-input">Protocol overhead (%):</label>
                 <input type="number" id="overhead-input" placeholder="0" min="0" max="100" step="any" aria-describedby="overhead-help">
                 <div id="overhead-help" class="sr-only">Enter protocol overhead percentage.</div>


### PR DESCRIPTION
## Summary
- support protocol selection (TCP or UDP) with IP version selection
- ask for latency when TCP is chosen and use it in the calculation
- show formulas used for the calculation
- include IPv4/IPv6 overhead presets and auto-selection logic

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684e532412c4832a85e8060c1dae35d0