### PR TITLE
Add formulas for advanced TCP metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
  # Transfer Time Calculator
 
 A static website for calculating theoretical transfer times and advanced TCP metrics based on file size,
-bandwidth and network protocol (TCP or UDP).
+bandwidth and network protocol (TCP or UDP). Hover over the question mark icons next to each result for a brief explanation of that metric.
 
  ## Prerequisites
  - bun (>=0.6.0) or Node.js (>=14)
@@ -51,6 +51,7 @@ bandwidth and network protocol (TCP or UDP).
    calculate the TCP handshake when applicable.
 6. (Optional) Pick an overhead preset such as Ethernet IPv4/TCP or MPLS to override the automatic value.
 7. Click **Calculate** to see the estimated transfer time.
+8. Hover over the question mark icons next to each result for an explanation of what the metric represents.
 
 ## Formulas
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ bandwidth and network protocol (TCP or UDP). Hover over the question mark icons 
    defaults take effect. The protocol and IP version inputs are also used to
    calculate the TCP handshake when applicable.
 6. (Optional) Pick an overhead preset such as Ethernet IPv4/TCP or MPLS to override the automatic value.
-7. Click **Calculate** to see the estimated transfer time.
-8. Hover over the question mark icons next to each result for an explanation of what the metric represents.
+7. (Optional) Adjust packet loss (default **0.001&nbsp;%**) and the TCP window size to see throughput limits.
+8. Click **Calculate** to see the estimated transfer time and metrics.
+9. Hover over the question mark icons next to each result for an explanation of what the metric represents.
 
 ## Formulas
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ bandwidth and network protocol (TCP or UDP). Hover over the question mark icons 
    calculate the TCP handshake when applicable.
 6. (Optional) Pick an overhead preset such as Ethernet IPv4/TCP or MPLS to override the automatic value.
 7. (Optional) Adjust packet loss (default **0.001&nbsp;%**) and the TCP window size to see throughput limits.
-8. Click **Calculate** to see the estimated transfer time and metrics.
+8. Click **Calculate** to see the minimum transfer time followed by the metrics used to derive it.
 9. Hover over the question mark icons next to each result for an explanation of what the metric represents.
 
 ## Formulas

--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
                 </div>
                 <div class="input-section">
                     <label for="loss-input">Packet loss (%):</label>
-                    <input type="number" id="loss-input" value="0" min="0" max="100" step="any" aria-describedby="loss-help">
-                    <div id="loss-help" class="sr-only">Packet loss percentage used for the Mathis throughput formula.</div>
+                    <input type="number" id="loss-input" value="0.001" min="0" max="100" step="any" aria-describedby="loss-help">
+                    <div id="loss-help" class="sr-only">Packet loss percentage used for the Mathis throughput formula. Default is 0.001%.</div>
                 </div>
                 <div class="input-section">
                     <label for="rwnd-input">TCP window size (bytes):</label>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
                 <button id="theme-toggle-btn" class="theme-toggle-btn" aria-describedby="theme-help" title="Toggle Dark Mode">&#9728;&#65039;</button>
             </div>
             <div id="theme-help" class="sr-only">Switch between light and dark theme</div>
-            <p>Calculate theoretical transfer time based on file size and bandwidth.</p>
+            <p>Calculate theoretical transfer time and TCP metrics based on file size and bandwidth.</p>
         </header>
         <main>
             <div class="input-section">
@@ -76,6 +76,16 @@
                     <label for="overhead-input">Protocol overhead (%):</label>
                     <input type="number" id="overhead-input" placeholder="0" min="0" max="100" step="any" aria-describedby="overhead-help">
                     <div id="overhead-help" class="sr-only">Enter protocol overhead percentage. Switching protocol or IP version clears the preset so defaults apply.</div>
+                </div>
+                <div class="input-section">
+                    <label for="loss-input">Packet loss (%):</label>
+                    <input type="number" id="loss-input" value="0" min="0" max="100" step="any" aria-describedby="loss-help">
+                    <div id="loss-help" class="sr-only">Packet loss percentage used for the Mathis throughput formula.</div>
+                </div>
+                <div class="input-section">
+                    <label for="rwnd-input">TCP window size (bytes):</label>
+                    <input type="number" id="rwnd-input" value="16777216" min="0" step="any" aria-describedby="rwnd-help">
+                    <div id="rwnd-help" class="sr-only">Receiver window size used to determine throughput limits.</div>
                 </div>
                 <div class="input-section" style="display: flex; gap: 10px; align-items: center;">
                     <label for="preset-select" class="sr-only">Overhead Preset</label>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "typescript": "^5.0.0"
   },
-  "description": "A simple static website for calculating theoretical transfer times based on file size and bandwidth",
+  "description": "A static website for calculating theoretical transfer times and advanced TCP metrics based on file size and bandwidth",
   "scripts": {
     "build": "tsc && rm -rf public && mkdir -p public && cp index.html styles.css public/ && cp -r dist public/",
     "dev": "tsc --watch",

--- a/src/main.ts
+++ b/src/main.ts
@@ -265,49 +265,51 @@ document.addEventListener('DOMContentLoaded', () => {
       return bps === Infinity ? 'Unlimited' : (bps / 1e6).toFixed(3) + ' Mbps';
     }
 
+    const helpIcon = (desc: string) => `<span class="help-icon" title="${desc}">?</span>`;
+
     resultDiv.innerHTML = `
       <div class="result-item">
-        <h3>Transfer Time Without Overhead:</h3>
+        <h3>Transfer Time Without Overhead: ${helpIcon('Time to transfer ignoring protocol overhead and handshake.')}</h3>
         <p>${timeStrRaw}</p>
         <p class="formula">${formulaRaw}</p>
       </div>
       <div class="result-item">
-        <h3>Transfer Time With Overhead:</h3>
+        <h3>Transfer Time With Overhead: ${helpIcon('Time including protocol overhead and handshake delay.')}</h3>
         <p>${timeStrOverhead}</p>
         <p class="formula">${formulaOverhead}</p>
       </div>
       <div class="result-item">
-        <h3>Bandwidth-Delay Product:</h3>
+        <h3>Bandwidth-Delay Product: ${helpIcon('Amount of data that can fill the link based on bandwidth and latency.')}</h3>
         <p>${bdpBits.toLocaleString()} bits (${bdpBytes.toLocaleString()} bytes)</p>
         <p class="formula">Formula: ${bwVal}${bwUnit.value} × ${latencyVal}ms / 1000 = ${bdpBits.toFixed(0)} bits</p>
       </div>
       <div class="result-item">
-        <h3>Minimum TCP Window Size:</h3>
+        <h3>Minimum TCP Window Size: ${helpIcon('Smallest receive window to fully utilize the link.')}</h3>
         <p>${bdpBytes.toLocaleString()} bytes</p>
         <p class="formula">Formula: ${bdpBits.toFixed(0)} bits ÷ 8 = ${bdpBytes.toFixed(0)} bytes</p>
       </div>
       <div class="result-item">
-        <h3>Max TCP Throughput with Overhead:</h3>
+        <h3>Max TCP Throughput with Overhead: ${helpIcon('Bandwidth available after subtracting protocol overhead.')}</h3>
         <p>${fmtMbps(maxOverheadBps)}</p>
         <p class="formula">${formulaOverheadBps}</p>
       </div>
       <div class="result-item">
-        <h3>Max TCP Throughput Limited by Packet Loss:</h3>
+        <h3>Max TCP Throughput Limited by Packet Loss: ${helpIcon('Theoretical limit based on packet loss probability.')}</h3>
         <p>${fmtMbps(lossBps)}</p>
         <p class="formula">${formulaLossBps}</p>
       </div>
       <div class="result-item">
-        <h3>Max TCP Throughput Limited by TCP Window:</h3>
+        <h3>Max TCP Throughput Limited by TCP Window: ${helpIcon('Limit imposed by the configured TCP receive window size.')}</h3>
         <p>${fmtMbps(rwndBps)}</p>
         <p class="formula">${formulaRwndBps}</p>
       </div>
       <div class="result-item">
-        <h3>Expected Maximum TCP Throughput:</h3>
+        <h3>Expected Maximum TCP Throughput: ${helpIcon('Overall throughput limited by bandwidth, overhead, loss and window.')}</h3>
         <p>${fmtMbps(expectedBps)}</p>
         <p class="formula">${formulaExpectedBps}</p>
       </div>
       <div class="result-item">
-        <h3>Minimum Transfer Time:</h3>
+        <h3>Minimum Transfer Time: ${helpIcon('Shortest possible time using the expected maximum throughput.')}</h3>
         <p>${timeStrExpected}</p>
         <p class="formula">${formulaMinTime} = ${timeSecExpected.toFixed(2)} seconds</p>
       </div>`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -269,47 +269,47 @@ document.addEventListener('DOMContentLoaded', () => {
 
     resultDiv.innerHTML = `
       <div class="result-item">
-        <h3>Transfer Time Without Overhead: ${helpIcon('Time to transfer ignoring protocol overhead and handshake.')}</h3>
+        <h3>Transfer Time Without Overhead: ${helpIcon('Simple transfer time without protocol overhead or handshake.')}</h3>
         <p>${timeStrRaw}</p>
         <p class="formula">${formulaRaw}</p>
       </div>
       <div class="result-item">
-        <h3>Transfer Time With Overhead: ${helpIcon('Time including protocol overhead and handshake delay.')}</h3>
+        <h3>Transfer Time With Overhead: ${helpIcon('Transfer time including protocol overhead and handshake delay.')}</h3>
         <p>${timeStrOverhead}</p>
         <p class="formula">${formulaOverhead}</p>
       </div>
       <div class="result-item">
-        <h3>Bandwidth-Delay Product: ${helpIcon('Amount of data that can fill the link based on bandwidth and latency.')}</h3>
+        <h3>Bandwidth-Delay Product: ${helpIcon('Bandwidth-Delay Product (BDP) = bandwidth × latency.')}</h3>
         <p>${bdpBits.toLocaleString()} bits (${bdpBytes.toLocaleString()} bytes)</p>
         <p class="formula">Formula: ${bwVal}${bwUnit.value} × ${latencyVal}ms / 1000 = ${bdpBits.toFixed(0)} bits</p>
       </div>
       <div class="result-item">
-        <h3>Minimum TCP Window Size: ${helpIcon('Smallest receive window to fully utilize the link.')}</h3>
+        <h3>Minimum TCP Window Size: ${helpIcon('Minimum TCP Receive Window (BDP / 8).')}</h3>
         <p>${bdpBytes.toLocaleString()} bytes</p>
         <p class="formula">Formula: ${bdpBits.toFixed(0)} bits ÷ 8 = ${bdpBytes.toFixed(0)} bytes</p>
       </div>
       <div class="result-item">
-        <h3>Max TCP Throughput with Overhead: ${helpIcon('Bandwidth available after subtracting protocol overhead.')}</h3>
+        <h3>Max TCP Throughput with Overhead: ${helpIcon('Effective Bandwidth after subtracting protocol overhead.')}</h3>
         <p>${fmtMbps(maxOverheadBps)}</p>
         <p class="formula">${formulaOverheadBps}</p>
       </div>
       <div class="result-item">
-        <h3>Max TCP Throughput Limited by Packet Loss: ${helpIcon('Theoretical limit based on packet loss probability.')}</h3>
+        <h3>Max TCP Throughput Limited by Packet Loss: ${helpIcon('Mathis et al. loss-based throughput formula.')}</h3>
         <p>${fmtMbps(lossBps)}</p>
         <p class="formula">${formulaLossBps}</p>
       </div>
       <div class="result-item">
-        <h3>Max TCP Throughput Limited by TCP Window: ${helpIcon('Limit imposed by the configured TCP receive window size.')}</h3>
+        <h3>Max TCP Throughput Limited by TCP Window: ${helpIcon('Throughput limited by TCP receive window (rwnd / RTT).')}</h3>
         <p>${fmtMbps(rwndBps)}</p>
         <p class="formula">${formulaRwndBps}</p>
       </div>
       <div class="result-item">
-        <h3>Expected Maximum TCP Throughput: ${helpIcon('Overall throughput limited by bandwidth, overhead, loss and window.')}</h3>
+        <h3>Expected Maximum TCP Throughput: ${helpIcon('Minimum of bandwidth, overhead, loss (Mathis) and window limits.')}</h3>
         <p>${fmtMbps(expectedBps)}</p>
         <p class="formula">${formulaExpectedBps}</p>
       </div>
       <div class="result-item">
-        <h3>Minimum Transfer Time: ${helpIcon('Shortest possible time using the expected maximum throughput.')}</h3>
+        <h3>Minimum Transfer Time: ${helpIcon('File size divided by expected maximum throughput.')}</h3>
         <p>${timeStrExpected}</p>
         <p class="formula">${formulaMinTime} = ${timeSecExpected.toFixed(2)} seconds</p>
       </div>`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -268,6 +268,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const helpIcon = (desc: string) => `<span class="help-icon" title="${desc}">?</span>`;
 
     resultDiv.innerHTML = `
+      <div class="result-item primary-result">
+        <h3>Minimum Transfer Time: ${helpIcon('File size divided by expected maximum throughput.')}</h3>
+        <p>${timeStrExpected}</p>
+        <p class="formula">${formulaMinTime} = ${timeSecExpected.toFixed(2)} seconds</p>
+      </div>
       <div class="result-item">
         <h3>Transfer Time Without Overhead: ${helpIcon('Simple transfer time without protocol overhead or handshake.')}</h3>
         <p>${timeStrRaw}</p>
@@ -307,11 +312,6 @@ document.addEventListener('DOMContentLoaded', () => {
         <h3>Expected Maximum TCP Throughput: ${helpIcon('Minimum of bandwidth, overhead, loss (Mathis) and window limits.')}</h3>
         <p>${fmtMbps(expectedBps)}</p>
         <p class="formula">${formulaExpectedBps}</p>
-      </div>
-      <div class="result-item">
-        <h3>Minimum Transfer Time: ${helpIcon('File size divided by expected maximum throughput.')}</h3>
-        <p>${timeStrExpected}</p>
-        <p class="formula">${formulaMinTime} = ${timeSecExpected.toFixed(2)} seconds</p>
       </div>`;
   });
 

--- a/styles.css
+++ b/styles.css
@@ -99,7 +99,7 @@ button:hover {
   font-size: 1.4rem;
 }
 .primary-result p {
-  font-weight: bold;
+  font-weight: normal;
 }
 /* Style for formula description below the result */
 .result-item .formula {

--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,12 @@ button:hover {
   border: 4px solid #000;
   background: #fff;
 }
+.primary-result h3 {
+  font-size: 1.4rem;
+}
+.primary-result p {
+  font-weight: bold;
+}
 /* Style for formula description below the result */
 .result-item .formula {
   margin-top: 5px;

--- a/styles.css
+++ b/styles.css
@@ -119,6 +119,18 @@ button:hover {
   text-align: center;
   font-size: 0.9rem;
 }
+.help-icon {
+  display: inline-block;
+  margin-left: 4px;
+  border: 2px solid #000;
+  border-radius: 50%;
+  width: 1em;
+  height: 1em;
+  line-height: 0.9em;
+  font-size: 0.8em;
+  text-align: center;
+  cursor: help;
+}
 .sr-only {
   position: absolute;
   width: 1px;
@@ -181,5 +193,9 @@ body.dark .result-item p:not(.formula) {
 body.dark .header-layer {
   border-color: #fff;
   background: #333;
+  color: #fff;
+}
+body.dark .help-icon {
+  border-color: #fff;
   color: #fff;
 }


### PR DESCRIPTION
## Summary
- show formulas for advanced throughput metrics in UI
- expand README with manual calculation of advanced metrics
- tweak page description to mention TCP metrics

## Testing
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684fa56c6268832a8b726549da12c6df