### PR TITLE
Simplify overhead options

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,30 +52,19 @@
             <details id="advanced-section">
                 <summary>Advanced Options</summary>
                 <div class="input-section">
-                    <label for="protocol-select">Protocol:</label>
-                    <select id="protocol-select" aria-describedby="protocol-help">
-                        <option value="TCP" selected>TCP</option>
-                        <option value="UDP">UDP</option>
-                    </select>
-                    <div id="protocol-help" class="sr-only">Choose TCP or UDP. For TCP, enter latency to include handshake time in the total.</div>
-                </div>
-                <div id="latency-section" class="input-section">
                     <label for="latency-input">Latency (ms):</label>
                     <input type="number" id="latency-input" value="10" min="0" step="any" aria-describedby="latency-help">
-                    <div id="latency-help" class="sr-only">Round-trip latency for TCP in milliseconds.</div>
-                </div>
-                <div class="input-section">
-                    <label for="ip-version-select">IP Version:</label>
-                    <select id="ip-version-select" aria-describedby="ip-version-help">
-                        <option value="IPv4" selected>IPv4</option>
-                        <option value="IPv6">IPv6</option>
-                    </select>
-                    <div id="ip-version-help" class="sr-only">Select IPv4 or IPv6. Changing this or the protocol resets the preset and applies the default overhead.</div>
+                    <div id="latency-help" class="sr-only">Round-trip latency in milliseconds.</div>
                 </div>
                 <div class="input-section">
                     <label for="overhead-input">Protocol overhead (%):</label>
                     <input type="number" id="overhead-input" placeholder="0" min="0" max="100" step="any" aria-describedby="overhead-help">
-                    <div id="overhead-help" class="sr-only">Enter protocol overhead percentage. Switching protocol or IP version clears the preset so defaults apply.</div>
+                    <div id="overhead-help" class="sr-only">Enter protocol overhead percentage. Adjust the preset or extra bytes to update this value automatically.</div>
+                </div>
+                <div class="input-section">
+                    <label for="extra-bytes-input">Extra header bytes:</label>
+                    <input type="number" id="extra-bytes-input" value="0" min="0" step="any" aria-describedby="extra-bytes-help">
+                    <div id="extra-bytes-help" class="sr-only">Additional bytes to add on top of the selected preset.</div>
                 </div>
                 <div class="input-section">
                     <label for="loss-input">Packet loss (%):</label>


### PR DESCRIPTION
## Summary
- streamline advanced options form
- compute overhead based on preset bytes and added bytes
- add VXLAN preset
- remove protocol and IP version fields
- update docs accordingly

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_685079fac7d0832ab8567bafeea3d5f3