### PR TITLE
Add MTU option and hide TCP metrics for UDP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
  # Transfer Time Calculator
 
-A static website for calculating theoretical transfer times and advanced TCP metrics based on file size,
-bandwidth and network protocol (TCP or UDP). Hover over the question mark icons next to each result for a brief explanation of that metric.
+A static website for calculating theoretical transfer times. TCP-specific metrics are displayed only when using TCP presets, and the MTU can be adjusted from its default of 1500 bytes. Hover over the question mark icons next to each result for a brief explanation of that metric.
 
  ## Prerequisites
  - bun (>=0.6.0) or Node.js (>=14)
@@ -45,11 +44,12 @@ bandwidth and network protocol (TCP or UDP). Hover over the question mark icons 
 2. Enter a file size and select its unit.
 3. Enter a bandwidth value and select its unit.
 4. (Optional) Enter the round-trip latency in milliseconds.
-5. (Optional) Pick an overhead preset (defaults to **Ethernet IPv4/TCP**) such as MPLS or VXLAN.
-6. (Optional) Add extra header bytes on top of the chosen preset. The resulting overhead percentage updates automatically.
-7. (Optional) Adjust packet loss (default **0.001&nbsp;%**) and the TCP window size to see throughput limits.
-8. Click **Calculate** to see the minimum transfer time followed by the metrics used to derive it.
-9. Hover over the question mark icons next to each result for an explanation of what the metric represents.
+5. (Optional) Specify the MTU in bytes (default **1500**) if your network uses jumbo frames.
+6. (Optional) Pick an overhead preset (defaults to **Ethernet IPv4/TCP**) such as MPLS or VXLAN.
+7. (Optional) Add extra header bytes on top of the chosen preset. The resulting overhead percentage updates automatically.
+8. (Optional) Adjust packet loss (default **0.001&nbsp;%**) and the TCP window size to see throughput limits.
+9. Click **Calculate** to see the minimum transfer time followed by the metrics used to derive it.
+10. Hover over the question mark icons next to each result for an explanation of what the metric represents.
 
 ## Formulas
 

--- a/index.html
+++ b/index.html
@@ -61,6 +61,11 @@
                     <div id="extra-bytes-help" class="sr-only">Additional bytes to add on top of the selected preset.</div>
                 </div>
                 <div class="input-section">
+                    <label for="mtu-input">MTU (bytes):</label>
+                    <input type="number" id="mtu-input" value="1500" min="0" step="any" aria-describedby="mtu-help">
+                    <div id="mtu-help" class="sr-only">Maximum Transmission Unit, default 1500 bytes.</div>
+                </div>
+                <div class="input-section">
                     <label for="loss-input">Packet loss (%):</label>
                     <input type="number" id="loss-input" value="0.001" min="0" max="100" step="any" aria-describedby="loss-help">
                     <div id="loss-help" class="sr-only">Packet loss percentage used for the Mathis throughput formula. Default is 0.001%.</div>


### PR DESCRIPTION
## Summary
- allow users to specify MTU instead of assuming 1500 bytes
- hide TCP-specific metrics when UDP headers are selected
- document new MTU feature and update usage steps

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6850f0a788f4832abc76415c51e9e690